### PR TITLE
Update examples/signon/package.json

### DIFF
--- a/examples/signon/package.json
+++ b/examples/signon/package.json
@@ -2,7 +2,7 @@
   "name": "passport-google-examples-signon",
   "version": "0.0.0",
   "dependencies": {
-    "express": ">= 0.0.0",
+    "express": "<= 2.5.11",
     "ejs": ">= 0.0.0",
     "passport": ">= 0.0.0",
     "passport-google": ">= 0.0.0"


### PR DESCRIPTION
Updated package.json so that it by doing npm install, it installs express 2.5.11 and the example should work.
