### PR TITLE
Update app.js

### DIFF
--- a/examples/signon/app.js
+++ b/examples/signon/app.js
@@ -45,7 +45,7 @@ passport.use(new GoogleStrategy({
 
 
 
-var app = express.createServer();
+var app = express();
 
 // configure Express
 app.configure(function() {


### PR DESCRIPTION
express.createServer() is deprecated, express
applications no longer inherit from http.Server,
please use:

  var app = express();
