### PR TITLE
fixes #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Passport-Google
 
+## Deprecated:
+
+Google has deprecated OpenID for new domains, use [passport-google-oauth](https://github.com/jaredhanson/passport-google-oauth) instead.
+
 [Passport](http://passportjs.org/) strategy for authenticating with [Google](http://www.google.com/)
 using OpenID 2.0.
 


### PR DESCRIPTION
Since http://passportjs.org/guide/google/ still points here, and many people have been burned, I thought it wise to let people know that this is deprecated.

fixes #25 
