### PR TITLE
Fix "cannot set property" by updateing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "main": "./lib/passport-google",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport-openid": "0.3.x"
+    "passport-openid": "0.4.x"
   },
   "devDependencies": {
     "vows": "0.6.x"


### PR DESCRIPTION
"passport-openid" dependency needs an update to 0.4.0+ otherwise it will cause: "Cannot set property "user" of undefined" if used with other strategies.